### PR TITLE
Designed Items API Endpoints for Categories and Items Feed and Updated the Database Model To Support The Design

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
-from .routers import cart_router, wallet_router, user_router
+from .routers import cart_router, wallet_router, user_router, items_router
 
 master_router = APIRouter()
 master_router.include_router(cart_router)
 master_router.include_router(wallet_router)
 master_router.include_router(user_router)
+master_router.include_router(items_router)

--- a/server/api/routers/__init__.py
+++ b/server/api/routers/__init__.py
@@ -1,3 +1,4 @@
 from .cart.cart import router as cart_router
 from .wallet.wallet import router as wallet_router
 from .user.user import router as user_router
+from .items import router as items_router

--- a/server/api/routers/items/__init__.py
+++ b/server/api/routers/items/__init__.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+from .categories import router as categories_router
+from .items import router as items_router
+
+router = APIRouter()
+router.include_router(categories_router)
+router.include_router(items_router)

--- a/server/api/routers/items/categories.py
+++ b/server/api/routers/items/categories.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from server.schemas import CategoryResponse
+from server.dependencies import get_db
+from typing import List
+
+router = APIRouter()
+
+@router.get("/items/categories", response_model=List[CategoryResponse])
+async def get_categories_by_supermarket(
+    supermarket_id: int = Query(..., description="ID of the supermarket to filter categories")
+) -> List[CategoryResponse]:
+    """
+    Fetch categories available in a specific supermarket (mock response).
+    """
+    # Mock response for frontend testing
+    return [
+        CategoryResponse(id=1, name="Dairy & Eggs"),
+        CategoryResponse(id=2, name="Fruits & Vegetables"),
+        CategoryResponse(id=3, name="Bakery")
+    ]
+

--- a/server/api/routers/items/items.py
+++ b/server/api/routers/items/items.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from server.schemas import ItemListResponse, ItemResponse
+from server.dependencies import get_db
+
+router = APIRouter()
+
+@router.get("/items", response_model=ItemListResponse)
+async def get_items_by_category_and_supermarket(
+    category_id: int = Query(..., description="ID of the category to filter items"),
+    supermarket_id: int = Query(..., description="ID of the supermarket to filter items")
+) -> ItemListResponse:
+    """
+    Fetch items for a given category and supermarket (mock response).
+    """
+    # Mock response for frontend testing
+    return ItemListResponse(
+        category_id=category_id,
+        category_name="Dairy & Eggs",  # Mock category name
+        items=[
+            ItemResponse(
+                id=1,
+                name="Milk",
+                photo_url="http://example.com/milk.jpg",
+                price=5.0,
+                description="Fresh milk from local farms.",
+                supermarket_id=supermarket_id
+            ),
+            ItemResponse(
+                id=2,
+                name="Cheese",
+                photo_url="http://example.com/cheese.jpg",
+                price=7.0,
+                description="Delicious cheddar cheese.",
+                supermarket_id=supermarket_id
+            )
+        ]
+    )

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -10,6 +10,7 @@ from .user import User
 from .user_orders import UserOrder
 from .stock_levels import StockLevel
 from .wallet import Wallet
+from .supermarket_categories import SupermarketCategory
 from .base import Base
 
 

--- a/server/models/categories.py
+++ b/server/models/categories.py
@@ -13,3 +13,5 @@ class Category(Base):
     name = Column(String, nullable=False)
 
     items = relationship("Item", back_populates="category")
+
+    supermarket_categories = relationship("SupermarketCategory", back_populates="category")

--- a/server/models/supermarket_categories.py
+++ b/server/models/supermarket_categories.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.orm import relationship
+from .base import Base
+
+class SupermarketCategory(Base):
+    __tablename__ = 'supermarket_categories'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    supermarket_id = Column(Integer, ForeignKey('supermarkets.id'), nullable=False)
+    category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
+
+    # Relationships for ORM convenience
+    supermarket = relationship("Supermarket", back_populates="supermarket_categories")
+    category = relationship("Category", back_populates="supermarket_categories")

--- a/server/models/supermarkets.py
+++ b/server/models/supermarkets.py
@@ -19,3 +19,4 @@ class Supermarket(Base):
 
     items = relationship("Item", back_populates="supermarket")
     order_slots = relationship("OrderSlot", back_populates="supermarket")
+    supermarket_categories = relationship("SupermarketCategory", back_populates="supermarket")

--- a/server/schemas/__init__.py
+++ b/server/schemas/__init__.py
@@ -1,3 +1,4 @@
 from .cart import CreateCartRequest, CartResponse, AddItemRequest, RemoveItemRequest, UpdateCartRequest, ViewCartResponse, CartItem
 from .wallet import WalletResponse, WalletTopUpRequest, WalletPaymentRequest
 from .user import AccountDetailsResponse, OrderHistoryResponse, OrderSummary
+from .items import CategoryResponse, ItemResponse, ItemListResponse

--- a/server/schemas/items.py
+++ b/server/schemas/items.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from typing import List
+
+# Response model for categories
+class CategoryResponse(BaseModel):
+    id: int
+    name: str
+
+# Response model for items
+class ItemResponse(BaseModel):
+    id: int
+    name: str
+    photo_url: str
+    price: float
+    description: str
+    supermarket_id: int
+
+# Response model for items by category
+class ItemListResponse(BaseModel):
+    category_id: int
+    category_name: str
+    items: List[ItemResponse]
+


### PR DESCRIPTION
Database Schema:
- Added supermarket_categories table to link categories to supermarkets.

- Updated Supermarket and Category models to include relationships with SupermarketCategory.

Schemas:
- Defined CategoryResponse, ItemResponse, and ItemListResponse in schemas/items.py.

Endpoints:
- Planned GET /items/categories to fetch categories by supermarket, returning mock responses.

- Planned GET /items to fetch items by category and supermarket, returning mock responses.

Notes:
- Excluded request models as query parameters are sufficient for the required functionality.

- Designed endpoints to facilitate frontend testing and development.
