### PR TITLE
Added Supermarket Feed API endpoint

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
-from .routers import cart_router, wallet_router, user_router, order_router
+from .routers import cart_router, wallet_router, user_router, order_router, supermarket_router
 
 master_router = APIRouter()
 master_router.include_router(cart_router)
 master_router.include_router(wallet_router)
 master_router.include_router(user_router)
 master_router.include_router(order_router)
+master_router.include_router(supermarket_router)
 
 

--- a/server/api/routers/__init__.py
+++ b/server/api/routers/__init__.py
@@ -3,3 +3,4 @@ from .wallet.wallet import router as wallet_router
 from .user.user import router as user_router
 from .order.order import router as order_router
 from .items import router as items_router
+from .supermarket.supermarket import router as supermarket_router

--- a/server/api/routers/supermarket/supermarket.py
+++ b/server/api/routers/supermarket/supermarket.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List
+
+from server.dependencies import get_db
+from server.schemas import SupermarketFeedResponse
+
+router = APIRouter()
+
+@router.get("/supermarket/feed", response_model=SupermarketFeedResponse)
+async def get_supermarket_feed(db: AsyncSession = Depends(get_db)) -> SupermarketFeedResponse:
+    """
+    Overview:
+    Fetch a list of supermarkets with their basic details.
+
+    Function Logic:
+    1. Query the database to retrieve supermarket details.
+    2. Filter active supermarkets if needed.
+    3. Return the supermarket data for the frontend.
+
+    Parameters:
+    - db (AsyncSession): Database session for querying data.
+
+    Returns:
+    - SupermarketFeedResponse: Encapsulated list of supermarkets.
+    """
+    # Mock response for frontend testing
+    return SupermarketFeedResponse(
+        success=True,
+        supermarkets=[
+            {
+                "id": 1,
+                "name": "Supermarket A",
+                "address": "123 Main St, City",
+                "phone_number": "123-456-7890",
+                "photo_url": "https://example.com/supermarket_a.jpg"
+            },
+            {
+                "id": 2,
+                "name": "Supermarket B",
+                "address": "456 Elm St, Town",
+                "phone_number": "987-654-3210",
+                "photo_url": "https://example.com/supermarket_b.jpg"
+            }
+        ]
+    )

--- a/server/schemas/__init__.py
+++ b/server/schemas/__init__.py
@@ -3,3 +3,4 @@ from .wallet import WalletResponse, WalletTopUpRequest, WalletPaymentRequest
 from .user import AccountDetailsResponse, OrderHistoryResponse, OrderSummary
 from .order import SubmitDeliveryDetailsRequest, SubmitDeliveryDetailsResponse, PaymentSummaryResponse, CancelOrderResponse, TrackOrderResponse, OrderSlotsResponse, AddressesResponse, Address, CartItem
 from .items import CategoryResponse, ItemResponse, ItemListResponse
+from .supermarket import SupermarketFeedResponse, Supermarket

--- a/server/schemas/supermarket.py
+++ b/server/schemas/supermarket.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+class Supermarket(BaseModel):
+    id: int
+    name: str
+    address: str
+    phone_number: str
+    photo_url: Optional[str] = None
+
+class SupermarketFeedResponse(BaseModel):
+    success: bool
+    supermarkets: List[Supermarket]
+
+
+


### PR DESCRIPTION
This PR introduces the Supermarket Feed API, which allows the frontend to fetch a list of supermarkets with basic details such as name, address, phone number, and optional photo.

New Endpoint: /supermarket/feed
- Fetches a list of supermarkets with mock data encapsulated in a SupermarketFeedResponse.

Returns:
-  success: Status of the operation.
- supermarkets: List of supermarkets.


Note: Mock data has been included in the response to support frontend integration testing.