### PR TITLE
Implement Wallet API Endpoints for Pay, Top-Up, and Check Balance

### DIFF
--- a/server/database.py
+++ b/server/database.py
@@ -35,7 +35,7 @@ DB_NAME = os.getenv('DATABASE_NAME')
 DATABASE_URL = f"postgresql+asyncpg://{DB_USERNAME}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 
 # Create asynchronous engine and session maker
-engine = create_async_engine(DATABASE_URL, echo=True)
+engine = create_async_engine(DATABASE_URL, echo=True, future=True)
 SessionLocal = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
 
 async def setup_database():

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -20,5 +20,5 @@ class User(Base):
     default_address = relationship("Address")
     cart = relationship("Cart", back_populates="user")
     transactions = relationship("WalletTransaction", back_populates="user", cascade="all, delete-orphan")
-    wallet = relationship("Wallet", back_populates="user")
+    wallet = relationship("Wallet", back_populates="user", uselist=False)
     shared_cart_contributors = relationship("SharedCartContributor", back_populates="user")

--- a/server/schemas/wallet.py
+++ b/server/schemas/wallet.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel, Field
 
 # Request model for topping up the wallet
 class WalletTopUpRequest(BaseModel):
+    user_id : int
     amount: float = Field(..., gt=0, description="Amount to add to the wallet.")
 
 # Response model for wallet operations
@@ -12,4 +13,5 @@ class WalletResponse(BaseModel):
 
 # Request model for paying from the wallet
 class WalletPaymentRequest(BaseModel):
+    user_id : int
     amount: float = Field(..., gt=0, description="Amount to deduct from the wallet.")


### PR DESCRIPTION
This PR introduces three Wallet-related API endpoints for managing user wallet operations within the system. These endpoints enable users to:

  1. Top-up their wallet.
  2. Make payments from their wallet.
  3. Check their current wallet balance.

Endpoints Added
1. POST /wallet/top-up
  Allows users to add funds to their wallet.
  Validates that the top-up amount is greater than zero.
  Returns the updated wallet balance after the top-up.

2. POST /wallet/pay
  Deducts a specified amount from the user's wallet balance.
  Validates that the payment amount is greater than zero.
  Ensures the wallet has sufficient funds before processing the payment.
  Returns the updated wallet balance after the transaction.

3. GET /wallet/balance
  Retrieves the current balance of a user's wallet.
  Validates the existence of the user and their associated wallet.
  Returns the wallet balance.